### PR TITLE
[finish] jbuilderの導入

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,9 @@
 class EventsController < ApplicationController
   def index
     @events = Event.all
+    respond_to do |format|
+      format.html
+      format.json {render 'calendar'}
+    end
   end
 end

--- a/app/javascript/packs/calendar.js
+++ b/app/javascript/packs/calendar.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var calendar = new Calendar(calendarEl, {
     plugins: [dayGridPlugin],
     initialView: 'dayGridMonth',
-    events: eventData
+    events: '/events'
   });
 
   calendar.render();

--- a/app/views/events/calendar.json.jbuilder
+++ b/app/views/events/calendar.json.jbuilder
@@ -1,0 +1,6 @@
+json.array!(@events) do |event|
+ json.id event.id
+ json.title event.title
+ json.start event.start.in_time_zone('Tokyo')
+ json.end event.end.in_time_zone('Tokyo')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: "events#index"
+  get '/events', to: 'events#index', defaults: {format: 'json'}
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
jbuilderを導入する事で、ビューファイルでインスタンス変数をjsonへ変換する過程を防ぎ、jbuilderが呼び出されるように、コントローラとルーティングを修正しました。